### PR TITLE
Add missing hashnode input param

### DIFF
--- a/src/commands/platforms/hashnode/index.js
+++ b/src/commands/platforms/hashnode/index.js
@@ -26,6 +26,7 @@ function postToHashnode(
     input: {
       title,
       contentMarkdown,
+      isPartOfPublication: { publicationId: configData.publicationId },
       tags: [],
     },
     publicationId: configData.publicationId,


### PR DESCRIPTION
This is a fix for issue #43. The request needed to be adjusted slightly to comply with the updated api. I tested the fix by attempting to publish to hashnode. Below is a screenshot of that test. 
![Test Screenshot.](https://github.com/shahednasser/cross-post/assets/86887236/4246f761-d69b-43a7-9f94-79d1f9b3be81)
