### PR TITLE
Fixes and updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
     'no-console': 'off',
     'default-case': 'off',
     'no-prototype-builtins': 'off',
+    'linebreak-style': 0,
   },
 };

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ Starting from version 1.2.3, you can now post local markdown files to the platfo
 For example:
 
 ```bash
-cross-post run /path/to/test.md -l
+# canonicalUrl is optional 
+cross-post run /path/to/test.md -l <canonicalUrl> 
 ```
 
 You can also use any of the previous options mentioned.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ For example:
 cross-post run /path/to/test.md -l <canonicalUrl> 
 ```
 
+### What is a canonical URL ?
+A canonical URL is the preferred version of a web page. It helps search engines understand which URL to index. Used to avoid duplicate content issues.
+It is used if your post is already published elsewhere but you still need more reach. So when publishing to a new vendor you would add that info so the website can point to the original poster.
+
 You can also use any of the previous options mentioned.
 
 #### Selector Configuration

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ program.usage('[command] [options]');
 program
   .command('run <url>')
   .description('Cross post a blog post')
-  .option('-l, --local', 'Use if the you want to directly post a local Markdown file. <url> in this case should be the path to the file')
+  .option('-l, --local [canonicalUrl]', 'For using a local Markdown file, <url> will be the path and <canonicalUrl> is optional')
   .option('-t, --title [title]', 'Title for the article')
   .option('-p, --platforms [platforms...]', `Platforms to post articles to. Allowed values are: ${allowedPlatforms.join(', ')}`)
   .option('-s, --selector [selector]', 'The selector to look for in the document in the URL supplied. By default, it will be article. '

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -292,11 +292,15 @@ async function run(url, options) {
       }
     }
     // create links for images in files
-    const articleDOM = local && await getRemoteArticleDOM(local);
-    const mainElement = local && findMainContentElements(articleDOM.window.document.body);
-    markdown = local ? formatMarkdownImages(markdown, mainElement, local) : markdown;
+    const isLocalAPath = typeof local === 'string';
 
-    postToPlatforms(title, markdown, local || url, image, p);
+    const articleDOM = isLocalAPath && await getRemoteArticleDOM(local);
+    const mainElement = isLocalAPath && findMainContentElements(articleDOM.window.document.body);
+    markdown = isLocalAPath ? formatMarkdownImages(markdown, mainElement, local) : markdown;
+    const newURL = local ? '' : url;
+    const canonicalURL = isLocalAPath ? local : newURL;
+
+    postToPlatforms(title, markdown, canonicalURL, image, p);
   } else {
     handleError('No articles found in the URL.');
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -160,7 +160,6 @@ const formatMarkdownImages = (markdown, element, url) => {
   const prefixUrl = (URL) => enforceHTTPS(!URL.startsWith('http://') && !URL.startsWith('https://') ? baseUrl + URL : URL);
 
   const imagesSrc = Array.from(element.querySelectorAll('img, picture')).map((HTMLImage) => {
-    // console.log(HTMLImage.outerHTML,`\n\n\n`);
     const { src, tagName } = HTMLImage || {};
 
     if (tagName.toLowerCase() === 'img') return src ? prefixUrl(src) : null;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,173 @@
 const chalk = require('chalk');
+const { get } = require('axios');
+const { JSDOM } = require('jsdom');
 
 const allowedPlatforms = ['dev', 'hashnode', 'medium'];
+
+/**
+ * Replaces the 'http' scheme with 'https' in a given URL.
+ *
+ * @function
+ * @name enforceHTTPS
+ * @param {string} url - The URL to be converted to HTTPS.
+ * @returns {string|null} - The URL with 'https' scheme, or null if the input is null.
+ *
+ * @example
+ * const url = "http://example.com";
+ * const httpsUrl = enforceHTTPS(url);  // Output will be "https://example.com"
+ */
+const enforceHTTPS = (url) => url?.replace(/^(http:\/\/)/, 'https://');
+
+/**
+ * Fetches the HTML content from a remote URL and returns it as a JSDOM object.
+ *
+ * @async
+ * @function
+ * @name getRemoteArticleDOM
+ * @param {string} url - The URL of the remote article to fetch.
+ * @returns {Promise<JSDOM>} - A promise that resolves to a JSDOM object containing
+ * the HTML content of the remote article.
+ */
+const getRemoteArticleDOM = async (url) => {
+  const { data } = await get(enforceHTTPS(url));
+  return new JSDOM(data);
+};
+
+/**
+ * Finds the nearest common ancestor of an array of HTML elements.
+ *
+ * @function
+ * @name findNearestCommonAncestor
+ * @param {HTMLElement[]} elements - An array of HTML elements for which to find
+ * the nearest common ancestor.
+ * @returns {HTMLElement|null} - The nearest common ancestor element, or null
+ * if the input array is empty or null.
+ *
+ * @example
+ * const elem1 = document.getElementById('elem1');
+ * const elem2 = document.getElementById('elem2');
+ * const commonAncestor = findNearestCommonAncestor([elem1, elem2]);
+ *
+ * // commonAncestor will contain the nearest common ancestor HTMLElement or null.
+ */
+const findNearestCommonAncestor = (elements) => {
+  if (elements?.length === 0) {
+    return null;
+  }
+  const findAncestors = (element, ancestorsSet) => {
+    if (element) {
+      ancestorsSet.add(element);
+      findAncestors(element.parentElement, ancestorsSet);
+    }
+  };
+  const ancestorsList = elements.map((element) => {
+    const ancestors = new Set();
+    findAncestors(element, ancestors);
+    return ancestors;
+  });
+
+  const commonAncestors = ancestorsList.reduce((acc, currSet) => acc
+    .filter((ancestor) => currSet.has(ancestor)), [...ancestorsList[0]]);
+
+  return commonAncestors[0] || null;
+};
+
+/**
+ * Ranks HTML elements based on how many text density it has
+ * and returns the top 20 elements that contain a `<p>` tag.
+ *
+ * @function
+ * @name rankingTag
+ * @param {HTMLElement} document - The HTML jsdom element representing the root of the document.
+ * @returns {HTMLElement[]} - An array of the top 20 HTMLElements that contain a `<p>` tag.
+ *
+ */
+const rankingTag = (document) => {
+  const elements = document.querySelectorAll('p, blockquote, h1, h2, h3, h4, h5, h6');
+  const scoreTag = {
+    p: 0.8,
+    blockquote: 0.9,
+    h1: 0.6,
+    h2: 0.6,
+    h3: 0.6,
+    h4: 0.6,
+    h5: 0.6,
+    h6: 0.6,
+  };
+
+  const { elementScores, elementHasPTag } = Array.from(elements).reduce(
+    (acc, element) => {
+      const textLength = element.textContent.length;
+      const tagName = element.tagName.toLowerCase();
+
+      if (tagName.includes('-')) {
+        return acc;
+      }
+
+      const scoreMultiplier = scoreTag[tagName];
+      const score = textLength * scoreMultiplier;
+      const { parentElement } = element;
+
+      if (parentElement && !parentElement.tagName.toLowerCase().includes('-')) {
+        if (acc.elementScores.has(parentElement)) {
+          acc.elementScores.set(parentElement, acc.elementScores.get(parentElement) + score);
+        } else {
+          acc.elementScores.set(parentElement, score);
+        }
+
+        if (tagName === 'p') {
+          acc.elementHasPTag.set(parentElement, true);
+        }
+      }
+
+      return acc;
+    },
+    { elementScores: new Map(), elementHasPTag: new Map() },
+  );
+
+  return Array.from(elementScores.entries())
+    .filter(([parentElement]) => elementHasPTag.has(parentElement))
+    .sort(([, scoreA], [, scoreB]) => scoreB - scoreA)
+    .slice(0, 20)
+    .map(([element]) => element);
+};
+const findMainContentElements = (document) => findNearestCommonAncestor(rankingTag(document));
+
+/**
+ * Formats Markdown images within the provided Markdown string.
+ *
+ * @function
+ * @name formatMarkdownImages
+ * @param {string} markdown - The Markdown text that needs to be formatted.
+ * @param {HTMLElement} element - The HTMLElement (from jsdom) where images will be extracted.
+ * @param {string} url - The URL to be used for setting the images absolute path
+ * @returns {string} - The formatted Markdown string.
+ *
+ * @example
+ * const markdown = "![Alt text](/path/to/image.jpg)";
+ * const element = new jsdom.window.HTMLElement('body');
+ * const url = "https://example.com";
+ * const result = '![Alt text](https://example.com/imagefromElement.png)'
+ */
+const formatMarkdownImages = (markdown, element, url) => {
+  const formattedUrl = new URL(url);
+  formattedUrl.pathname = '';
+  formattedUrl.search = '';
+  formattedUrl.hash = '';
+
+  const baseUrl = formattedUrl.toString();
+
+  const imagesSrc = Array.from(element.getElementsByTagName('img')).map((HTMLImage) => {
+    const { src } = HTMLImage;
+    const newSrc = !src.startsWith('http://') && !src.startsWith('https://') ? baseUrl + src : src;
+    return enforceHTTPS(newSrc);
+  });
+  const GRAB_IMAGES_MARKDOWN_REGEX = /!\[(.*?)]\((.*?)\)/g;
+  return markdown.replace(GRAB_IMAGES_MARKDOWN_REGEX, (match, p1, p2) => {
+    const newUrl = imagesSrc.shift() || p2;
+    return `![${p1}](${newUrl})`;
+  });
+};
 
 module.exports = {
   allowedPlatforms,
@@ -20,4 +187,7 @@ module.exports = {
     return !!s.match(regex);
   },
   imagePlatform: 'cloudinary',
+  findMainContentElements,
+  getRemoteArticleDOM,
+  formatMarkdownImages,
 };


### PR DESCRIPTION
hi @shahednasser,

I have created several functions on this PR.

The main goal is to allow more freedom when deploying locally using markdown files. The functions could be extended to other parts of the code yet I wanted to keep it simple to make a point that we probably do not need to rely on selectors

crosspost run <file-path> -l <canonical-url> 

This command goes to a remote location where the blog is already posted. It grabs the HTML and will apply some algorithms to determine the main content div (instead of the --selector approach). It will then merge the src images with the markdown [](image).
i.e [whatever](/assets/dogimage.png) => [whatever](https://localcanonicalurl.com/doggoimage.png

The approach is to use text density and specific text tags and try to match the common nearest selector between these.


I have also added a cross configuration between OS in this repo in order to prevent conflict between two different environments (CRLF vs. LF). I use Windows and you probably use macOS. 

I have added JSDOC style docs to the function the way you used across the files.  It is worth noting that  I code a little bit differently than this current codebase. If you need me to change anything please let me know.


I have also added a few fixes that were breaking the cli, fixed some eslint complaining and all.  Hope it is okay. Thanks again.
Anything let me know. 👍 

